### PR TITLE
Make collapsing transition work for main content container

### DIFF
--- a/app/components/layout/Footer/Footer.jsx
+++ b/app/components/layout/Footer/Footer.jsx
@@ -1,8 +1,13 @@
 import styles from "./Footer.module.css";
 
-export default function Footer() {
+export default function Footer({ hasContent }) {
   return (
-    <footer className={styles.footer}>
+    <footer
+      className={styles.footer}
+      style={{
+        borderTop: hasContent ? "2px solid #000" : "none",
+      }}
+    >
       <div className={styles.footerContent}>
         <div className={styles.contatos}>
           <a href="#" data-page="contatos" className={styles.contatos}>

--- a/app/components/layout/Header/Header.jsx
+++ b/app/components/layout/Header/Header.jsx
@@ -52,7 +52,9 @@ function Title() {
           src="/archive/icons/imagem.jpeg"
           width={60}
           height={60}
-          alt="bla"
+          alt="Desenho de um rosto"
+          aria-hidden={true}
+          priority
         />
       </div>
     </div>

--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 
 import AboutMe from "./components/content/AboutMe/AboutMe";
 import Footer from "./components/layout/Footer/Footer";
@@ -17,61 +18,23 @@ const menuItems = [
   { title: "Etcetera", id: "etcetera" },
 ];
 
-const transitionDuration = 0.5; // Change desired transition duration here
+const transitionDuration = 0.5; // Duration of animations in seconds
 
 export default function Home() {
   const [activeTab, setActiveTab] = useState(null);
-  const [isTransitioning, setIsTransitioning] = useState(false);
   const [hasContent, setHasContent] = useState(false);
-  const mainContentRef = useRef(null);
 
   const handleTabClick = (id) => {
-    if (isTransitioning) return; // Prevent overlapping transitions
+    setActiveTab(id === activeTab ? null : id);
+  };
 
-    if (!mainContentRef.current) {
-      setActiveTab(id);
-      setHasContent(true);
-      return; // Exit early to prevent height manipulations
-    }
+  useEffect(() => {
+    setHasContent(activeTab ? true : false);
+  }, [activeTab]);
 
-    setIsTransitioning(true);
-
-    // Start collapsing the main content
-    if (mainContentRef.current) {
-      mainContentRef.current.style.height = mainContentRef.current.scrollHeight
-        ? `${mainContentRef.current.scrollHeight}px`
-        : "70svh"; // On the first render scrollHeight doesn't exist, so 70% of the small viewport height is the default
-      mainContentRef.current.style.transition = `height ${transitionDuration}s ease`;
-      requestAnimationFrame(() => {
-        mainContentRef.current.style.height = "0px";
-      });
-    }
-
-    // Wait for the collapse transition to complete before changing the tab
-    setTimeout(() => {
-      setActiveTab(id === activeTab ? null : id);
-
-      // Start expanding the main content
-      if (mainContentRef.current) {
-        mainContentRef.current.style.height = "0px"; // Ensure height starts at 0
-        requestAnimationFrame(() => {
-          mainContentRef.current.style.transition = `height ${transitionDuration}s ease`;
-          const newHeight =
-            mainContentRef.current.scrollHeight || id === activeTab
-              ? `${mainContentRef.current.scrollHeight}px`
-              : "70svh";
-
-          mainContentRef.current.style.height = newHeight;
-
-          setHasContent(newHeight !== "0px");
-        });
-      }
-
-      // Wait for the expansion to finish
-      setTimeout(() => {
-        setIsTransitioning(false);
-      }, transitionDuration * 1000);
-    }, transitionDuration * 1000);
+  const variants = {
+    hidden: { height: 0, opacity: 0 },
+    visible: { height: "auto", opacity: 1 },
   };
 
   return (
@@ -82,12 +45,52 @@ export default function Home() {
         handleTabClick={handleTabClick}
       />
       <main>
-        <div className={styles.mainContent} ref={mainContentRef}>
-          {activeTab === "aboutMe" && <AboutMe />}
-          {activeTab === "publications" && <Publications />}
-          {/* {activeTab === "projects" && <Projects />} */}
-          {/* Add other contents as necessary */}
-        </div>
+        <motion.div
+          className={styles.mainContent}
+          initial="hidden"
+          animate={activeTab ? "visible" : "hidden"}
+          variants={variants}
+          transition={{ duration: transitionDuration, ease: "easeInOut" }}
+        >
+          <AnimatePresence mode="wait">
+            {activeTab === "aboutMe" && (
+              <motion.div
+                key="aboutMe"
+                initial="hidden"
+                animate="visible"
+                exit="hidden"
+                variants={variants}
+                transition={{ duration: transitionDuration }}
+              >
+                <AboutMe />
+              </motion.div>
+            )}
+            {activeTab === "publications" && (
+              <motion.div
+                key="publications"
+                initial="hidden"
+                animate="visible"
+                exit="hidden"
+                variants={variants}
+                transition={{ duration: transitionDuration }}
+              >
+                <Publications />
+              </motion.div>
+            )}
+            {/* {activeTab === "projects" && (
+              <motion.div
+                key="projects"
+                initial="hidden"
+                animate="visible"
+                exit="hidden"
+                variants={variants}
+                transition={{ duration: transitionDuration }}
+              >
+                <Projects />
+              </motion.div>
+            )} */}
+          </AnimatePresence>
+        </motion.div>
         <Footer hasContent={hasContent} />
       </main>
     </div>

--- a/app/page.js
+++ b/app/page.js
@@ -17,7 +17,7 @@ const menuItems = [
   { title: "Etcetera", id: "etcetera" },
 ];
 
-export const transitionDuration = 0.5; // Change desired transition duration here
+const transitionDuration = 0.5; // Change desired transition duration here
 
 export default function Home() {
   const [activeTab, setActiveTab] = useState(null);

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,13 +1,8 @@
 .mainContent {
   overflow: hidden;
-  transition: height 2s ease;
+  transition: height 1s ease;
   height: 0;
   border-bottom: none;
-}
-
-.active {
-  height: auto; /* Necessário para ajustar a altura conforme o conteúdo */
-  border-bottom: 2px solid #000;
 }
 
 /* Style da página "et cetera" */

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "react": "19.0.0-rc-66855b96-20241106",
-    "react-dom": "19.0.0-rc-66855b96-20241106",
-    "next": "15.0.3"
+    "motion": "^11.11.14",
+    "next": "15.0.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   }
 }


### PR DESCRIPTION
# Descrição

Faz a animação de fechar o container do conteúdo principal funcionar. Do modo que está agora, primeiro o container é fechado, depois o conteúdo é trocar, por fim, o conteúdo é aberto.

Também foi criada uma variável para controlar a velocidade da transição. Essa velocidade não está atrelada ao tempo de movimentação do Header.

Fiz também uma pequena modificação no Header para garantir acessibilidade e uma FCP melhor.

# Gravação de tela
![enrico-demo](https://github.com/user-attachments/assets/a20ae640-9d70-4d88-a766-6087f974a7ad)

